### PR TITLE
[FEATURE] 보유 품목 페이지 API 연동

### DIFF
--- a/src/apis/inventory/inventory.js
+++ b/src/apis/inventory/inventory.js
@@ -1,0 +1,87 @@
+import api from '../Instance';
+
+// 보유 품목 전체 조회 API
+export const ownItemAllApi = async () => {
+  try {
+    const res = await api.get('api/owns');
+
+    console.log('보유 품목 조회 성공:', res.data);
+    return { ok: true, data: res.data };
+  } catch (error) {
+    console.error(error);
+    return { ok: false, data: null };
+  }
+};
+
+// 보유 품목 수동 추가 API
+export const ownItemAddApi = async (itemData) => {
+  try {
+    const res = await api.post('api/owns', {
+      nickname: itemData.ownName,
+      ownCount: itemData.ownCount,
+      ownCategory: itemData.ownCategory,
+    });
+
+    console.log('보유 품목 수정 성공:', res.data);
+    return { ok: true, data: res.data };
+  } catch (error) {
+    console.error(error);
+    return { ok: false, data: null };
+  }
+};
+
+// 보유 품목 단건 조회 API
+export const ownItemOneApi = async (ownId) => {
+  try {
+    const res = await api.get(`api/owns/${ownId}`);
+
+    console.log('보유 품목 단건 조회 성공:', res.data);
+    return { ok: true, data: res.data };
+  } catch (error) {
+    console.error(error);
+    return { ok: false, data: null };
+  }
+};
+
+// 보유 품목 삭제 API
+export const ownItemDeleteApi = async (ownId) => {
+  try {
+    const res = await api.delete(`api/owns/${ownId}`);
+
+    console.log('보유 품목 삭제 성공:', res.data);
+    return { ok: true, data: res.data };
+  } catch (error) {
+    console.error(error);
+    return { ok: false, data: null };
+  }
+};
+
+// 보유 품목 수정 API
+export const ownItemEditApi = async (ownId, data) => {
+  try {
+    const res = await api.patch(`api/owns/${ownId}`, {
+      ownName: data.ownName,
+      ownCount: data.ownCount,
+      ownCategory: data.ownCategory,
+    });
+
+    console.log('보유 품목 수정 성공:', res.data);
+    return { ok: true, data: res.data };
+  } catch (error) {
+    console.error(error);
+    return { ok: false, data: null };
+  }
+};
+
+// 보유 품목 소진된 품목 조회 API
+export const ownItemDepletedApi = async () => {
+  try {
+    const res = await api.get(`api/owns/depleted`);
+
+    console.log('소진된 품목 조회 성공:', res.data);
+    return { ok: true, data: res.data };
+  } catch (error) {
+    console.error(error);
+    return { ok: false, data: null };
+  }
+};

--- a/src/apis/inventory/inventory.js
+++ b/src/apis/inventory/inventory.js
@@ -17,7 +17,7 @@ export const ownItemAllApi = async () => {
 export const ownItemAddApi = async (itemData) => {
   try {
     const res = await api.post('api/owns', {
-      nickname: itemData.ownName,
+      ownName: itemData.ownName,
       ownCount: itemData.ownCount,
       ownCategory: itemData.ownCategory,
     });

--- a/src/data/category.js
+++ b/src/data/category.js
@@ -11,3 +11,31 @@ export const categorys = [
   '음료·주류',
   '기타',
 ];
+
+export const LABEL_TO_KEY_MAP = {
+  전체: 'ALL',
+  '채소·과일류': 'VEGETABLES_FRUITS',
+  수산물: 'SEAFOOD',
+  육류: 'MEAT',
+  '달걀·유제품류': 'EGGS_DAIRY',
+  '곡류·견과류': 'GRAINS_NUTS',
+  '조미류·양념류': 'SEASONINGS',
+  냉동식품: 'FROZEN_FOOD',
+  가공식품: 'PROCESSED_FOOD',
+  '음료·주류': 'BEVERAGES_ALCOHOL',
+  기타: 'ETC',
+};
+
+export const KEY_TO_LABEL_MAP = {
+  ALL: '전체',
+  VEGETABLES_FRUITS: '채소·과일류',
+  SEAFOOD: '수산물',
+  MEAT: '육류',
+  EGGS_DAIRY: '달걀·유제품류',
+  GRAINS_NUTS: '곡류·견과류',
+  SEASONINGS: '조미류·양념류',
+  FROZEN_FOOD: '냉동식품',
+  PROCESSED_FOOD: '가공식품',
+  BEVERAGES_ALCOHOL: '음료·주류',
+  ETC: '기타',
+};

--- a/src/pages/InventoryPage/InventoryPage.jsx
+++ b/src/pages/InventoryPage/InventoryPage.jsx
@@ -3,7 +3,7 @@ import styles from './InventoryPage.module.scss';
 import { blankBubble, glasses } from '@/assets';
 import { Button } from '@/components/Button/Button';
 import { SortSelect } from './components/SortSelect';
-import { categorys } from '@/data/category';
+import { categorys, LABEL_TO_KEY_MAP, KEY_TO_LABEL_MAP } from '@/data/category';
 import { ItemEditorModal } from './components/ItemEditorModal';
 import { ExhaustedListModal } from './components/ExhaustedListModal';
 import { IoClose } from 'react-icons/io5';
@@ -12,7 +12,7 @@ import { ownItemAllApi } from '@/apis/inventory/inventory';
 export const InventoryPage = () => {
   const [allItems, setAllItems] = useState([]);
   const [searchTerm, setSearchTerm] = useState('');
-  const [selectCategory, setSelectCategory] = useState('전체');
+  const [selectCategoryKey, setSelectCategoryKey] = useState('ALL');
   const [sortBy, setSortBy] = useState('등록순');
 
   const [isManualEditorModalOpen, setIsManualEditorModalOpen] = useState(false);
@@ -24,13 +24,13 @@ export const InventoryPage = () => {
     const filteredItems = allItems
       .filter((item) => {
         // 카테고리 필터
-        return selectCategory === '전체'
+        return selectCategoryKey === 'ALL'
           ? true
-          : item.category === selectCategory;
+          : item.ownCategory === selectCategoryKey;
       })
       .filter((item) => {
         // 검색어 필터
-        return item.name.toLowerCase().includes(searchTerm.toLowerCase());
+        return item.ownName.toLowerCase().includes(searchTerm.toLowerCase());
       });
 
     // 사본 만들어서 작업
@@ -38,15 +38,15 @@ export const InventoryPage = () => {
 
     // 정렬
     if (sortBy === '등록순') {
-      sortedItems.sort((a, b) => b.id - a.id);
+      sortedItems.sort((a, b) => b.ownId - a.ownId);
     } else if (sortBy === '이름순') {
-      sortedItems.sort((a, b) => a.name.localeCompare(b.name));
+      sortedItems.sort((a, b) => a.ownName.localeCompare(b.ownName));
     } else if (sortBy === '재고순') {
-      sortedItems.sort((a, b) => b.count - a.count);
+      sortedItems.sort((a, b) => b.ownCount - a.ownCount);
     }
 
     return sortedItems;
-  }, [allItems, selectCategory, searchTerm, sortBy]);
+  }, [allItems, selectCategoryKey, searchTerm, sortBy]);
 
   // API 통신
   useEffect(() => {
@@ -89,17 +89,20 @@ export const InventoryPage = () => {
       </div>
       <div className={styles.content}>
         <div className={styles.categoryList}>
-          {categorys.map((category, index) => (
-            <div
-              key={index}
-              className={`${styles.category} ${
-                selectCategory === category && styles.active
-              }`}
-              onClick={() => setSelectCategory(category)}
-            >
-              {category}
-            </div>
-          ))}
+          {categorys.map((categoryLabel, index) => {
+            const categoryKey = LABEL_TO_KEY_MAP[categoryLabel];
+            return (
+              <div
+                key={index}
+                className={`${styles.category} ${
+                  selectCategoryKey === categoryKey && styles.active
+                }`}
+                onClick={() => setSelectCategoryKey(categoryKey)}
+              >
+                {categoryLabel}
+              </div>
+            );
+          })}
         </div>
         <div className={styles.itemListContainer}>
           <div className={styles.itemListHeader}>
@@ -136,7 +139,7 @@ export const InventoryPage = () => {
                       title="품목 상세"
                       initName={item.ownName}
                       initCount={item.ownCount}
-                      initCategory={item.ownCategory}
+                      initCategory={KEY_TO_LABEL_MAP[item.ownCategory]}
                       initAddDate={item.expiryDate}
                       placeholder={item.name}
                       closeModal={() => setEditingItemId(null)}

--- a/src/pages/InventoryPage/InventoryPage.jsx
+++ b/src/pages/InventoryPage/InventoryPage.jsx
@@ -56,8 +56,12 @@ export const InventoryPage = () => {
         setAllItems(data.data);
       }
     };
-    getAllItems();
-  }, []);
+
+    // 수정 완료 후 널일 때 실행(+ 에디터 모달, 소진 모달에서 작업 완료 후 다시 불러오기)
+    if (editingItemId === null) {
+      getAllItems();
+    }
+  }, [isManualEditorModalOpen, editingItemId, isExhaustedListModalOpen]);
 
   return (
     <div className={styles.container}>
@@ -118,7 +122,7 @@ export const InventoryPage = () => {
             )}
             <SortSelect setSelected={setSortBy} />
           </div>
-          {processedList.length === 0 ? (
+          {processedList.filter((item) => item.ownCount > 0).length === 0 ? (
             <div className={styles.blankBox}>
               <img src={blankBubble} />
               <span>
@@ -127,28 +131,30 @@ export const InventoryPage = () => {
             </div>
           ) : (
             <div className={styles.itemList}>
-              {processedList.map((item) => (
-                <div
-                  key={item.ownId}
-                  className={styles.itemRow}
-                  onClick={() => setEditingItemId(item.ownId)}
-                >
-                  {editingItemId === item.ownId && (
-                    <ItemEditorModal
-                      ownId={item.ownId}
-                      title="품목 상세"
-                      initName={item.ownName}
-                      initCount={item.ownCount}
-                      initCategory={KEY_TO_LABEL_MAP[item.ownCategory]}
-                      initAddDate={item.expiryDate}
-                      placeholder={item.name}
-                      closeModal={() => setEditingItemId(null)}
-                    />
-                  )}
-                  <span className={styles.itemName}>{item.ownName}</span>
-                  <span className={styles.itemCount}>{item.ownCount}개</span>
-                </div>
-              ))}
+              {processedList
+                .filter((item) => item.ownCount > 0)
+                .map((item) => (
+                  <div
+                    key={item.ownId}
+                    className={styles.itemRow}
+                    onClick={() => setEditingItemId(item.ownId)}
+                  >
+                    {editingItemId === item.ownId && (
+                      <ItemEditorModal
+                        ownId={item.ownId}
+                        title="품목 상세"
+                        initName={item.ownName}
+                        initCount={item.ownCount}
+                        initCategory={KEY_TO_LABEL_MAP[item.ownCategory]}
+                        initAddDate={item.expiryDate}
+                        placeholder={item.name}
+                        closeModal={() => setEditingItemId(null)}
+                      />
+                    )}
+                    <span className={styles.itemName}>{item.ownName}</span>
+                    <span className={styles.itemCount}>{item.ownCount}개</span>
+                  </div>
+                ))}
             </div>
           )}
           <div className={styles.button}>

--- a/src/pages/InventoryPage/InventoryPage.jsx
+++ b/src/pages/InventoryPage/InventoryPage.jsx
@@ -2,12 +2,12 @@ import { useEffect, useMemo, useState } from 'react';
 import styles from './InventoryPage.module.scss';
 import { blankBubble, glasses } from '@/assets';
 import { Button } from '@/components/Button/Button';
-import { inventoryData } from '@/data/inventoryMock';
 import { SortSelect } from './components/SortSelect';
 import { categorys } from '@/data/category';
 import { ItemEditorModal } from './components/ItemEditorModal';
 import { ExhaustedListModal } from './components/ExhaustedListModal';
 import { IoClose } from 'react-icons/io5';
+import { ownItemAllApi } from '@/apis/inventory/inventory';
 
 export const InventoryPage = () => {
   const [allItems, setAllItems] = useState([]);
@@ -19,10 +19,6 @@ export const InventoryPage = () => {
   const [editingItemId, setEditingItemId] = useState(null);
   const [isExhaustedListModalOpen, setIsExhaustedListModalOpen] =
     useState(false);
-
-  useEffect(() => {
-    setAllItems(inventoryData);
-  }, []);
 
   const processedList = useMemo(() => {
     const filteredItems = allItems
@@ -51,6 +47,17 @@ export const InventoryPage = () => {
 
     return sortedItems;
   }, [allItems, selectCategory, searchTerm, sortBy]);
+
+  // API 통신
+  useEffect(() => {
+    const getAllItems = async () => {
+      const { ok, data } = await ownItemAllApi();
+      if (ok) {
+        setAllItems(data.data);
+      }
+    };
+    getAllItems();
+  }, []);
 
   return (
     <div className={styles.container}>
@@ -119,23 +126,24 @@ export const InventoryPage = () => {
             <div className={styles.itemList}>
               {processedList.map((item) => (
                 <div
-                  key={item.id}
+                  key={item.ownId}
                   className={styles.itemRow}
-                  onClick={() => setEditingItemId(item.id)}
+                  onClick={() => setEditingItemId(item.ownId)}
                 >
-                  {editingItemId === item.id && (
+                  {editingItemId === item.ownId && (
                     <ItemEditorModal
+                      ownId={item.ownId}
                       title="품목 상세"
-                      initName={item.name}
-                      initCount={item.count}
-                      initCategory={item.category}
+                      initName={item.ownName}
+                      initCount={item.ownCount}
+                      initCategory={item.ownCategory}
                       initAddDate={item.expiryDate}
                       placeholder={item.name}
                       closeModal={() => setEditingItemId(null)}
                     />
                   )}
-                  <span className={styles.itemName}>{item.name}</span>
-                  <span className={styles.itemCount}>{item.count}개</span>
+                  <span className={styles.itemName}>{item.ownName}</span>
+                  <span className={styles.itemCount}>{item.ownCount}개</span>
                 </div>
               ))}
             </div>

--- a/src/pages/InventoryPage/components/ExhaustedListModal.jsx
+++ b/src/pages/InventoryPage/components/ExhaustedListModal.jsx
@@ -12,13 +12,13 @@ export const ExhaustedListModal = ({ closeModal }) => {
   const [itemData, setItemData] = useState([]);
   const [selectedItems, setSelectedItems] = useState([]);
 
-  // 체크박스(라디오버튼) 클릭 핸들러(현재는 이름으로 받아오지만 고유 id로 변경해야 함)
-  const handleCheckboxClick = (item) => {
-    if (selectedItems.includes(item)) {
-      const temp = selectedItems.filter((el) => el !== item);
+  // 체크박스(라디오버튼) 클릭 핸들러
+  const handleCheckboxClick = (id) => {
+    if (selectedItems.includes(id)) {
+      const temp = selectedItems.filter((el) => el !== id);
       setSelectedItems(temp);
     } else {
-      setSelectedItems((prev) => [...prev, item]);
+      setSelectedItems((prev) => [...prev, id]);
     }
   };
 
@@ -33,11 +33,17 @@ export const ExhaustedListModal = ({ closeModal }) => {
   }, []);
 
   const deleteItems = async () => {
-    selectedItems.map(async (item) => {
-      await ownItemDeleteApi(item.ownId);
+    const deletePromises = selectedItems.map((id) => {
+      return ownItemDeleteApi(id);
     });
-    console.log('소진된 품목 삭제 완료');
-    closeModal();
+
+    try {
+      await Promise.all(deletePromises);
+      console.log('소진된 품목 삭제 완료');
+      closeModal();
+    } catch (error) {
+      console.error('소진 품목 삭제 중 오류 발생:', error);
+    }
   };
 
   return (

--- a/src/pages/InventoryPage/components/ExhaustedListModal.jsx
+++ b/src/pages/InventoryPage/components/ExhaustedListModal.jsx
@@ -1,11 +1,15 @@
-import { inventoryData } from '@/data/inventoryMock';
 import styles from './ExhaustedListModal.module.scss';
 import { IoClose } from 'react-icons/io5';
 import { blankBubble, checkboxCheck } from '@/assets';
 import { Button } from '@/components/Button/Button';
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
+import {
+  ownItemDeleteApi,
+  ownItemDepletedApi,
+} from '@/apis/inventory/inventory';
 
 export const ExhaustedListModal = ({ closeModal }) => {
+  const [itemData, setItemData] = useState([]);
   const [selectedItems, setSelectedItems] = useState([]);
 
   // 체크박스(라디오버튼) 클릭 핸들러(현재는 이름으로 받아오지만 고유 id로 변경해야 함)
@@ -18,6 +22,24 @@ export const ExhaustedListModal = ({ closeModal }) => {
     }
   };
 
+  useEffect(() => {
+    const getItemData = async () => {
+      const { ok, data } = await ownItemDepletedApi();
+      if (ok) {
+        setItemData(data.data);
+      }
+    };
+    getItemData();
+  }, []);
+
+  const deleteItems = async () => {
+    selectedItems.map(async (item) => {
+      await ownItemDeleteApi(item.ownId);
+    });
+    console.log('소진된 품목 삭제 완료');
+    closeModal();
+  };
+
   return (
     <div className={styles.backdrop}>
       <div className={styles.container}>
@@ -27,7 +49,7 @@ export const ExhaustedListModal = ({ closeModal }) => {
           <IoClose className={styles.closeIcon} onClick={closeModal} />
         </div>
         <div className={styles.listContainer}>
-          {inventoryData.length === 0 ? (
+          {itemData.length === 0 ? (
             <div className={styles.blankBox}>
               <img src={blankBubble} />
               <span>
@@ -37,21 +59,21 @@ export const ExhaustedListModal = ({ closeModal }) => {
             </div>
           ) : (
             <div className={styles.itemList}>
-              {inventoryData.map((item, index) => (
-                <div key={index} className={styles.itemRow}>
+              {itemData.map((item) => (
+                <div key={item.ownId} className={styles.itemRow}>
                   <div
                     className={styles.left}
-                    onClick={() => handleCheckboxClick(item)}
+                    onClick={() => handleCheckboxClick(item.ownId)}
                   >
-                    {selectedItems.includes(item) ? (
+                    {selectedItems.includes(item.ownId) ? (
                       <img src={checkboxCheck} />
                     ) : (
                       <div className={styles.checkButton}></div>
                     )}
-                    <span className={styles.itemName}>{item.name}</span>
+                    <span className={styles.itemName}>{item.ownName}</span>
                   </div>
                   <span className={styles.date}>
-                    소진일자 {item.expiryDate}
+                    소진일자 {item.purchaseDate}
                   </span>
                 </div>
               ))}
@@ -60,22 +82,12 @@ export const ExhaustedListModal = ({ closeModal }) => {
         </div>
         {selectedItems.length !== 0 && (
           <div className={styles.buttonContainer}>
-            <div className={styles.buttonContent}>
-              <Button
-                text="리스트에 추가하기"
-                isActive={true}
-                onClick={() => {}}
-                padding="11px 15px"
-              />
-            </div>
-            <div className={styles.buttonContent}>
-              <Button
-                text="삭제하기"
-                isActive={true}
-                onClick={() => {}}
-                padding="11px 15px"
-              />
-            </div>
+            <Button
+              text="소진품목 삭제하기"
+              isActive={true}
+              onClick={deleteItems}
+              padding="11px 15px"
+            />
           </div>
         )}
       </div>

--- a/src/pages/InventoryPage/components/ItemEditorModal.jsx
+++ b/src/pages/InventoryPage/components/ItemEditorModal.jsx
@@ -41,7 +41,7 @@ export const ItemEditorModal = ({
     }
   };
 
-  const handleDeleteOwnItem = async (ownId) => {
+  const handleDeleteOwnItem = async () => {
     const { ok } = await ownItemDeleteApi(ownId);
     if (ok) {
       setIsDeleteModalOpen(false);

--- a/src/pages/InventoryPage/components/ItemEditorModal.jsx
+++ b/src/pages/InventoryPage/components/ItemEditorModal.jsx
@@ -53,29 +53,31 @@ export const ItemEditorModal = ({
     if (!itemName || !category || category === '전체' || !addDate) {
       setFailToastOpen(true);
     } else {
-      const categoryKey = LABEL_TO_KEY_MAP[category];
-      // 수정인 경우
-      if (ownId) {
-        const { ok } = await ownItemEditApi(ownId, {
-          ownName: itemName,
-          ownCount: count,
-          ownCategory: categoryKey,
-        });
-        if (ok) {
-          setSuccessToastOpen(true);
-          setTimeout(() => closeModal(), TOAST_DELAY + 300);
+      if (!successToastOpen) {
+        const categoryKey = LABEL_TO_KEY_MAP[category];
+        // 수정인 경우
+        if (ownId) {
+          const { ok } = await ownItemEditApi(ownId, {
+            ownName: itemName,
+            ownCount: count,
+            ownCategory: categoryKey,
+          });
+          if (ok) {
+            setSuccessToastOpen(true);
+            setTimeout(() => closeModal(), TOAST_DELAY + 300);
+          }
         }
-      }
-      // 수동 추가인 경우
-      else {
-        const { ok } = await ownItemAddApi({
-          ownName: itemName,
-          ownCount: count,
-          ownCategory: categoryKey,
-        });
-        if (ok) {
-          setSuccessToastOpen(true);
-          setTimeout(() => closeModal(), TOAST_DELAY + 300);
+        // 수동 추가인 경우
+        else {
+          const { ok } = await ownItemAddApi({
+            ownName: itemName,
+            ownCount: count,
+            ownCategory: categoryKey,
+          });
+          if (ok) {
+            setSuccessToastOpen(true);
+            setTimeout(() => closeModal(), TOAST_DELAY + 300);
+          }
         }
       }
     }

--- a/src/pages/InventoryPage/components/ItemEditorModal.jsx
+++ b/src/pages/InventoryPage/components/ItemEditorModal.jsx
@@ -1,6 +1,6 @@
 import { useRef, useState } from 'react';
 import styles from './ItemEditorModal.module.scss';
-import { categorys } from '@/data/category';
+import { categorys, LABEL_TO_KEY_MAP } from '@/data/category';
 import { buttonCancel, buttonCheck, penIcon } from '@/assets';
 import { LuPlus } from 'react-icons/lu';
 import { LuMinus } from 'react-icons/lu';
@@ -37,15 +37,16 @@ export const ItemEditorModal = ({
   };
 
   const handleSaveClick = async () => {
-    if (!itemName || !category || !addDate) {
+    if (!itemName || !category || category === '전체' || !addDate) {
       setFailToastOpen(true);
     } else {
+      const categoryKey = LABEL_TO_KEY_MAP[category];
       // 수정인 경우
       if (ownId) {
         const { ok } = await ownItemEditApi(ownId, {
           ownName: itemName,
           ownCount: count,
-          ownCategory: category,
+          ownCategory: categoryKey,
         });
         if (ok) {
           setSuccessToastOpen(true);
@@ -57,7 +58,7 @@ export const ItemEditorModal = ({
         const { ok } = await ownItemAddApi({
           ownName: itemName,
           ownCount: count,
-          ownCategory: category,
+          ownCategory: categoryKey,
         });
         if (ok) {
           setSuccessToastOpen(true);
@@ -130,17 +131,19 @@ export const ItemEditorModal = ({
           </div>
         </div>
         <div className={styles.categoryContainer}>
-          {categorys.map((c, index) => (
-            <div
-              key={index}
-              className={`${styles.category} ${
-                c === category && styles.active
-              }`}
-              onClick={() => setCategory(c)}
-            >
-              {c}
-            </div>
-          ))}
+          {categorys
+            .filter((c) => c !== '전체')
+            .map((c, index) => (
+              <div
+                key={index}
+                className={`${styles.category} ${
+                  c === category && styles.active
+                }`}
+                onClick={() => setCategory(c)}
+              >
+                {c}
+              </div>
+            ))}
         </div>
         <div className={styles.addDateContainer}>
           <span className={styles.dateTitle}>구매일자(등록일자)</span>

--- a/src/pages/InventoryPage/components/ItemEditorModal.jsx
+++ b/src/pages/InventoryPage/components/ItemEditorModal.jsx
@@ -7,7 +7,11 @@ import { LuMinus } from 'react-icons/lu';
 import { IoIosWarning } from 'react-icons/io';
 import { FaCheckCircle } from 'react-icons/fa';
 import { ItemEditorToast } from './ItemEditorToast';
-import { ownItemAddApi, ownItemEditApi } from '@/apis/inventory/inventory';
+import {
+  ownItemAddApi,
+  ownItemDeleteApi,
+  ownItemEditApi,
+} from '@/apis/inventory/inventory';
 
 const TOAST_DELAY = 2000;
 
@@ -27,12 +31,21 @@ export const ItemEditorModal = ({
   const [addDate, setAddDate] = useState(initAddDate);
   const [failToastOpen, setFailToastOpen] = useState(false);
   const [successToastOpen, setSuccessToastOpen] = useState(false);
+  const [isDeleteModalOpen, setIsDeleteModalOpen] = useState(false);
 
   const dateInputRef = useRef(null);
 
   const handleDateClick = () => {
     if (dateInputRef.current) {
       dateInputRef.current.showPicker();
+    }
+  };
+
+  const handleDeleteOwnItem = async (ownId) => {
+    const { ok } = await ownItemDeleteApi(ownId);
+    if (ok) {
+      setIsDeleteModalOpen(false);
+      closeModal();
     }
   };
 
@@ -70,7 +83,40 @@ export const ItemEditorModal = ({
 
   return (
     <div className={styles.backdrop}>
-      <div className={styles.container}>
+      {/* 품목 삭제 모달 */}
+      {isDeleteModalOpen && (
+        <div className={styles.deleteModalContainer}>
+          <IoIosWarning
+            style={{ width: '35px', height: '35px', color: '#F56E00' }}
+          />
+          <div className={styles.deleteModalText}>
+            <h1 className={styles.deleteModalHeader}>{itemName}</h1>
+            <span className={styles.deleteModalCaption}>
+              이 품목을 보유 품목에서 <span>삭제</span>하시겠어요?
+            </span>
+          </div>
+          <div className={styles.deleteModalButtonContent}>
+            <div
+              className={styles.buttonCancel}
+              onClick={(e) => {
+                e.stopPropagation();
+                setIsDeleteModalOpen(false);
+              }}
+            >
+              <img src={buttonCancel} />
+            </div>
+            <div className={styles.buttonCheck} onClick={handleDeleteOwnItem}>
+              <img src={buttonCheck} />
+            </div>
+          </div>
+        </div>
+      )}
+      <div
+        className={`${styles.container} ${
+          isDeleteModalOpen && styles.modalOpen
+        }`}
+      >
+        {/* 추가 실패 토스트 */}
         {failToastOpen && (
           <ItemEditorToast
             Img={
@@ -83,6 +129,7 @@ export const ItemEditorModal = ({
             delay={TOAST_DELAY}
           />
         )}
+        {/* 품목 수정/완료 토스트 */}
         {successToastOpen && (
           <ItemEditorToast
             Img={
@@ -161,17 +208,29 @@ export const ItemEditorModal = ({
           </div>
         </div>
         <div className={styles.buttonContainer}>
-          <div
-            className={styles.buttonCancel}
-            onClick={(e) => {
-              e.stopPropagation();
-              closeModal();
-            }}
-          >
-            <img src={buttonCancel} />
-          </div>
-          <div className={styles.buttonCheck} onClick={handleSaveClick}>
-            <img src={buttonCheck} />
+          {ownId && (
+            <div
+              className={styles.buttonDelete}
+              onClick={() => {
+                setIsDeleteModalOpen(true);
+              }}
+            >
+              품목 삭제
+            </div>
+          )}
+          <div className={styles.buttonContent}>
+            <div
+              className={styles.buttonCancel}
+              onClick={(e) => {
+                e.stopPropagation();
+                closeModal();
+              }}
+            >
+              <img src={buttonCancel} />
+            </div>
+            <div className={styles.buttonCheck} onClick={handleSaveClick}>
+              <img src={buttonCheck} />
+            </div>
           </div>
         </div>
       </div>

--- a/src/pages/InventoryPage/components/ItemEditorModal.jsx
+++ b/src/pages/InventoryPage/components/ItemEditorModal.jsx
@@ -7,10 +7,12 @@ import { LuMinus } from 'react-icons/lu';
 import { IoIosWarning } from 'react-icons/io';
 import { FaCheckCircle } from 'react-icons/fa';
 import { ItemEditorToast } from './ItemEditorToast';
+import { ownItemAddApi, ownItemEditApi } from '@/apis/inventory/inventory';
 
 const TOAST_DELAY = 2000;
 
 export const ItemEditorModal = ({
+  ownId = null,
   title = '보유품목 수동등록',
   placeholder = '추가할 품목 입력',
   initName = '',
@@ -34,12 +36,34 @@ export const ItemEditorModal = ({
     }
   };
 
-  const handleSaveClick = () => {
+  const handleSaveClick = async () => {
     if (!itemName || !category || !addDate) {
       setFailToastOpen(true);
     } else {
-      setSuccessToastOpen(true);
-      setTimeout(() => closeModal(), TOAST_DELAY + 300);
+      // 수정인 경우
+      if (ownId) {
+        const { ok } = await ownItemEditApi(ownId, {
+          ownName: itemName,
+          ownCount: count,
+          ownCategory: category,
+        });
+        if (ok) {
+          setSuccessToastOpen(true);
+          setTimeout(() => closeModal(), TOAST_DELAY + 300);
+        }
+      }
+      // 수동 추가인 경우
+      else {
+        const { ok } = await ownItemAddApi({
+          ownName: itemName,
+          ownCount: count,
+          ownCategory: category,
+        });
+        if (ok) {
+          setSuccessToastOpen(true);
+          setTimeout(() => closeModal(), TOAST_DELAY + 300);
+        }
+      }
     }
   };
 

--- a/src/pages/InventoryPage/components/ItemEditorModal.module.scss
+++ b/src/pages/InventoryPage/components/ItemEditorModal.module.scss
@@ -13,6 +13,18 @@
   background-color: rgba(0, 0, 0, 0.7);
   z-index: 1001;
   padding: 0 16px;
+
+  .modalOpen {
+    &::after {
+      content: '';
+      position: absolute;
+      width: 100%;
+      height: 100%;
+      background-color: rgba(0, 0, 0, 0.7);
+      border-radius: 10px;
+    }
+  }
+
   .container {
     @include flex(column, $gap: 20px);
     position: relative;
@@ -121,15 +133,81 @@
     }
 
     .buttonContainer {
-      @include flex($justify-content: flex-end, $gap: 6px);
+      @include flex($justify-content: space-between);
+      width: 100%;
+
+      .buttonDelete {
+        @include flex();
+        @include hoverEvent();
+        flex: 1 0 auto;
+        padding: 8.5px 10px;
+        border-radius: 7px;
+        border: 1px solid $color-primary;
+        color: $color-primary;
+        background-color: white;
+        font-size: 18px;
+        font-weight: $font-weight-bold;
+      }
+      .buttonContent {
+        @include flex($justify-content: flex-end, $gap: 6px);
+        width: 100%;
+        .buttonCancel {
+          @include buttonStyle();
+          height: 40px;
+          img {
+          }
+        }
+        .buttonCheck {
+          @include buttonStyle($color-primary);
+          height: 40px;
+          img {
+          }
+        }
+      }
+    }
+  }
+
+  .deleteModalContainer {
+    @include flex(column, $gap: 15px);
+    position: absolute;
+    z-index: 1003;
+    border-radius: 10px;
+    background: #fff;
+    padding: 18px 0;
+    width: calc(100% - 32px);
+    .deleteModalText {
+      @include flex(column, $gap: 5px);
+      color: #000;
+      .deleteModalHeader {
+        text-align: center;
+        font-size: 20px;
+        font-weight: 600;
+        line-height: 130%; /* 26px */
+      }
+      .deleteModalCaption {
+        color: #000;
+        text-align: center;
+        font-size: 17px;
+        font-weight: 400;
+        span {
+          color: #f56e00;
+          font-size: 17px;
+          font-weight: 600;
+        }
+      }
+    }
+    .deleteModalButtonContent {
+      @include flex($gap: 15px);
       width: 100%;
       .buttonCancel {
         @include buttonStyle();
+        height: 40px;
         img {
         }
       }
       .buttonCheck {
         @include buttonStyle($color-primary);
+        height: 40px;
         img {
         }
       }

--- a/src/pages/MyPage/components/NicknameEditModal.jsx
+++ b/src/pages/MyPage/components/NicknameEditModal.jsx
@@ -7,7 +7,7 @@ export const NicknameEditModal = ({ nickname, closeModal }) => {
   const [modifyNickname, setModifyNickname] = useState(nickname);
 
   const handleSaveClick = async () => {
-    const { ok } = nicknameEditApi(modifyNickname);
+    const { ok } = await nicknameEditApi(modifyNickname);
     if (ok) {
       closeModal();
     }


### PR DESCRIPTION
## ✨ 작업 개요

<!-- 어떤 기능을 구현했는지 간단히 설명해주세요. -->
보유 품목 페이지 API 연동
## 📌 관련 이슈

- close #18 

## ✅ 작업 내용

- 보유품목 페이지 API 연동
  - 보유품목 조회, 소진품목 조회 API 연동
  - 보유품목 수동 추가, 수정 API 연동
  - 보유품목 삭제, 소진 품목 삭제 API 연동
- 보유품목 카테고리 백엔드 엔티티에 맞게 매핑 수정
- 보유품목 수정 모달에 삭제 버튼 및 기능 추가 

